### PR TITLE
fix typo "ingore" to "ignore", fix #37

### DIFF
--- a/code/xsim.definitions.code.tex
+++ b/code/xsim.definitions.code.tex
@@ -75,7 +75,7 @@
 \DeclareExerciseTagging {tags}
 \DeclareExerciseTagging {topics}
 
-\xsimsetup{tags/ingore-untagged=false}
+\xsimsetup{tags/ignore-untagged=false}
 
 % ----------------------------------------------------------------------------
 

--- a/code/xsim.tags.code.tex
+++ b/code/xsim.tags.code.tex
@@ -54,7 +54,7 @@
     \bool_new:c {l____xsim_tagged_#1_bool}
     \keys_define:nn {xsim}
       {
-        #1/ingore-untagged .bool_set:c = {l__xsim_ignore_untagged_#1_bool} ,
+        #1/ignore-untagged .bool_set:c = {l__xsim_ignore_untagged_#1_bool} ,
         #1/ignore-untagged .initial:n  = true ,
         #1                 .code:n     =
           \xsim_set_seq_from_clist:cn {l__xsim_chosen_tags_#1_seq} {##1}

--- a/doc/examples/xsim.various.tex
+++ b/doc/examples/xsim.various.tex
@@ -66,7 +66,7 @@
 \xsimsetup{
   % tags = {geometry} ,
   % topics = {geometry}
-  % tags/ingore-untagged % if true untagged exercise will be printed regardless
+  % tags/ignore-untagged % if true untagged exercise will be printed regardless
   %                      % which tags have been chosen
 }
 

--- a/doc/xsim_manual.tex
+++ b/doc/xsim_manual.tex
@@ -709,7 +709,7 @@ following code:
 \begin{sourcecode}
   \DeclareExerciseTagging{tags}
   \DeclareExerciseTagging{topics}
-  \xsimsetup{tags/ingore-untagged=false}
+  \xsimsetup{tags/ignore-untagged=false}
 \end{sourcecode}
 This means that these options are available:
 \begin{options}


### PR DESCRIPTION
Although file `xsim_manual.tex` is changed, PDF manual is not reproduced.