### PR TITLE
fix typo in doc

### DIFF
--- a/doc/xsim_manual.tex
+++ b/doc/xsim_manual.tex
@@ -1536,7 +1536,7 @@ Table templates are used by \cs{gradingtable}.  Those are the templates set
 with the option \option{template} of module \module{grading-table}
 
 The predefined templates are \enquote{\code{default}} and
-\enquote{\code{default}}, see sections~\vref{sec:table-templ-default}
+\enquote{\code{default*}}, see sections~\vref{sec:table-templ-default}
 and~\vref{sec:table-templ-default*}.
 
 \subsection{Examples}\label{sec:template-examples}


### PR DESCRIPTION
change 

    The predefined (heading) templates are default and default

to

    The predefined (heading) templates are default and default*