### PR TITLE
document the blank/fill option

### DIFF
--- a/doc/xsim-manual.tex
+++ b/doc/xsim-manual.tex
@@ -2138,6 +2138,10 @@ Similar to \pkg{exsheets} \xsim\ provides a command \cs{blank}:
 
 Those are the options for customization:
 \begin{options}
+  \keyval{fill}{bool}\Module{blank}\Default{false}
+    If set to true, this will show the correct answers in the blanks within
+    the exercise if solutions are printed, without the need to repeat the
+    whole exercise content in the solution.
   \keyval{blank-style}{code}\Module{blank}\Default{\cs*{underline}\Marg{\#1}}
     Instructions for typesetting the blank cloze.  Refer to the filled in
     space with \code{\#1}.


### PR DESCRIPTION
I just stumbled upon your SO answer [here](https://tex.stackexchange.com/a/390056/195582) on how to make blanks show the correct solution within the exercise body if solutions are printed, without the need to repeat all the exercise content in the solution (which is super useful). It seems that this code actually already made it into xsim, it was just not documented. I'm not quite sure how the documentation works, but this should fix that.

PS: thanks again for all the nice work on this package, we use it productively to make our exams by now, I just didn't have the time to comment on the issue regarding nested exercises / points in exams yet :sweat_smile: 