### PR TITLE
Fix random numbers unavailable warning

### DIFF
--- a/code/xsim.random.code.tex
+++ b/code/xsim.random.code.tex
@@ -1,11 +1,12 @@
 \XSIMmodule{random}{randomly select exercises from collections}
 
 \msg_new:nnn {xsim} {random-numbers-unavailable}
-  {
-    You~ are~ compiling~ your~ document~ using ~XeLaTeX.~ Please~ be~ aware~
-    that~ random~ selection~ of~ exercises~ is~ unavailable~ in~ XeLaTeX.~ If~
-    you~ use~ this~ feature~ you~ can~ safely~ ignore~ this~ message.
-  }
+{
+  You~ are~ compiling~ your~ document~ using~ XeLaTeX.~ Please~ be~ aware~
+  that~ random~ selection~ of~ exercises~ is~ not~ available~ in~ XeLaTeX.~
+  If~ you~ are~ not~ using~ this~ feature,~ you~ can~ safely~ ignore~ this~
+  message.
+}
 
 \sys_if_engine_xetex:T
   { \msg_warning:nn {xsim} {random-numbers-unavailable} }

--- a/code/xsim.sty
+++ b/code/xsim.sty
@@ -4225,9 +4225,10 @@
 
 \msg_new:nnn {xsim} {random-numbers-unavailable}
   {
-    You~ are~ compiling~ your~ document~ using ~XeLaTeX.~ Please~ be~ aware~
-    that~ random~ selection~ of~ exercises~ is~ unavailable~ in~ XeLaTeX.~ If~
-    you~ use~ this~ feature~ you~ can~ safely~ ignore~ this~ message.
+    You~ are~ compiling~ your~ document~ using~ XeLaTeX.~ Please~ be~ aware~ 
+    that~ random~ selection~ of~ exercises~ is~ not~ available~ in~ XeLaTeX.~ 
+    If~ you~ are~ not~ using~ this~ feature,~ you~ can~ safely~ ignore~ this~ 
+    message.
   }
 
 \sys_if_engine_xetex:T


### PR DESCRIPTION
When using the package with XeLaTeX, the package warns you about the random selection of exercises. The last sentence is missing a 'not'. I also improved the sentence for better readability.